### PR TITLE
Update for "Docker for Mac" Version 17.06.0-ce-mac19

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ create_docker_network() {
   esac
 
   log Create host-accessible network
-  docker network create -o com.docker.network.bridge.name=$netintf $network
+  docker network create $network
 }
 
 bridge_docker_network() {


### PR DESCRIPTION
Hi @mal, 

thank you for your script! It helps me a lot. I'm using it with the following command: 
`  $ DOCKER_TAP_NETWORK=docker_default ./install.sh tuntap_20150118.pkg`
and I get the following error if I try to start my containers with "docker-compose up -d" from the directory "docker": 
  `ERROR: Network "docker_default" needs to be recreated - option "com.docker.network.bridge.name" has changed> (Version 17.06.0-ce-mac19)`
If I remove the option "-o com.docker.network.bridge.name=$netintf" from your script it works perfectly.
I'm not aware if this option is relevant for previous versions of "Docker for Mac" but I wanted to share with you my findings.